### PR TITLE
Added metadata 'name' entry.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "zip_app"
 maintainer       "Fletcher Nichol"
 maintainer_email "fnichol@nichol.ca"
 license          "Apache 2.0"


### PR DESCRIPTION
While provisioning a vagrant mac os x base box I got the following error message:

Ridley cannot continue without a valid metadata 'name' entry.